### PR TITLE
Fix hardcoded /Users/iamanmp/ paths - make paths dynamic

### DIFF
--- a/cli/claude-os-consolidate.sh
+++ b/cli/claude-os-consolidate.sh
@@ -4,8 +4,10 @@
 
 set -e  # Exit on error
 
-CLAUDE_OS_DIR="/Users/iamanmp/Projects/claude-os"
-USER_CLAUDE_DIR="/Users/iamanmp/.claude"
+# Dynamically determine Claude OS directory from script location
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLAUDE_OS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+USER_CLAUDE_DIR="${HOME}/.claude"
 TEMPLATES_DIR="${CLAUDE_OS_DIR}/templates"
 
 echo "🔧 Claude OS Consolidation Script"
@@ -124,7 +126,7 @@ if [ -f "$INIT_SKILL_MD" ]; then
     cp "$INIT_SKILL_MD" "${INIT_SKILL_MD}.backup"
 
     # Replace hardcoded user paths with relative paths
-    sed -i.bak 's|/Users/iamanmp/.claude/|~/.claude/|g' "$INIT_SKILL_MD"
+    sed -i.bak 's|'"${USER_CLAUDE_DIR}"'/|~/.claude/|g' "$INIT_SKILL_MD"
     rm -f "${INIT_SKILL_MD}.bak"
     echo "   ✅ Updated initialize-project/SKILL.md"
 fi
@@ -136,7 +138,7 @@ if [ -f "$REMEMBER_SKILL_MD" ]; then
     cp "$REMEMBER_SKILL_MD" "${REMEMBER_SKILL_MD}.backup"
 
     # Replace hardcoded user paths
-    sed -i.bak 's|/Users/iamanmp/.claude/|~/.claude/|g' "$REMEMBER_SKILL_MD"
+    sed -i.bak 's|'"${USER_CLAUDE_DIR}"'/|~/.claude/|g' "$REMEMBER_SKILL_MD"
     rm -f "${REMEMBER_SKILL_MD}.bak"
     echo "   ✅ Updated remember-this/SKILL.md"
 fi

--- a/frontend/src/components/ProjectManagement.tsx
+++ b/frontend/src/components/ProjectManagement.tsx
@@ -34,7 +34,7 @@ export default function ProjectManagement() {
   const [showProjectSetup, setShowProjectSetup] = useState<number | null>(null);
   const [selectedProjectForSetup, setSelectedProjectForSetup] = useState<any>(null);
   const [projectName, setProjectName] = useState('');
-  const [projectPath, setProjectPath] = useState('/Users/iamanmp/Projects');
+  const [projectPath, setProjectPath] = useState('');
   const [projectDesc, setProjectDesc] = useState('');
   const [createError, setCreateError] = useState<string | null>(null);
   const [showPathPicker, setShowPathPicker] = useState(false);
@@ -165,7 +165,7 @@ export default function ProjectManagement() {
                     </button>
                   </div>
                   <p className="text-xs text-light-grey mt-2">
-                    Default: /Users/iamanmp/Projects
+                    Enter the full path to your project directory
                   </p>
                 </div>
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -72,7 +72,7 @@ Changes will apply to NEW projects only. Existing projects keep their CLAUDE.md 
 
 ## Consolidation Scripts
 
-See `/Users/iamanmp/Projects/claude-os/cli/` for scripts to:
+See the `cli/` directory in this repository for scripts to:
 - Move commands from `~/.claude/commands/` to `templates/commands/`
 - Move skills from `~/.claude/skills/` to `templates/skills/`
 - Update existing projects to use templates

--- a/templates/commands/claude-os-init.md
+++ b/templates/commands/claude-os-init.md
@@ -15,6 +15,12 @@ You are helping the user initialize a new project with Claude OS. This is a mult
 
 ## Process
 
+### Step 0: Determine Claude OS Directory
+
+Derive `{claude_os_dir}` from the path of this command file - it is two directories up from this file's location. For example, if this file is at `/home/user/repos/claude-os/templates/commands/claude-os-init.md`, then `{claude_os_dir}` is `/home/user/repos/claude-os`.
+
+Use this path for all template references below.
+
 ### Step 1: Gather Project Information
 
 Ask the user the following questions (provide smart defaults when possible):
@@ -143,13 +149,14 @@ mkdir -p .claude-os
 ```
 
 **Copy and customize CLAUDE.md:**
-- Read template from: `/Users/iamanmp/Projects/claude-os/templates/project-files/CLAUDE.md.template`
+- Read template from: `{claude_os_dir}/templates/project-files/CLAUDE.md.template`
 - Replace variables:
   - `{{PROJECT_NAME}}` → project_name
   - `{{PROJECT_DESCRIPTION}}` → description
   - `{{TECH_STACK}}` → tech_stack
   - `{{DATABASE}}` → database
   - `{{DEV_ENVIRONMENT}}` → dev_environment
+  - `{{CLAUDE_OS_DIR}}` → {claude_os_dir}
   - `{{PROJECT_SPECIFIC_CONTENT}}` → empty for now
   - `{{DEVELOPMENT_GUIDELINES}}` → empty for now
   - `{{COMMON_TASKS}}` → empty for now
@@ -157,7 +164,7 @@ mkdir -p .claude-os
 - Write to: `./CLAUDE.md`
 
 **Create .claude-os/config.json:**
-- Read template from: `/Users/iamanmp/Projects/claude-os/templates/project-files/.claude-os/config.json.template`
+- Read template from: `{claude_os_dir}/templates/project-files/.claude-os/config.json.template`
 - Replace variables:
   - `{{PROJECT_NAME}}` → project_name
   - `{{CLAUDE_OS_URL}}` → claude_os_url
@@ -169,12 +176,12 @@ mkdir -p .claude-os
 - Write to: `./.claude-os/config.json`
 
 **Create .claude-os/hooks.json:**
-- Read template from: `/Users/iamanmp/Projects/claude-os/templates/project-files/.claude-os/hooks.json.template`
+- Read template from: `{claude_os_dir}/templates/project-files/.claude-os/hooks.json.template`
 - Replace `{{PROJECT_NAME}}` → project_name
 - Write to: `./.claude-os/hooks.json`
 
 **Copy .gitignore:**
-- Copy from: `/Users/iamanmp/Projects/claude-os/templates/project-files/.claude-os/.gitignore`
+- Copy from: `{claude_os_dir}/templates/project-files/.claude-os/.gitignore`
 - Write to: `./.claude-os/.gitignore`
 
 **If Agent-OS is enabled (`ENABLE_AGENT_OS=true`):**
@@ -190,17 +197,17 @@ mkdir -p .claude-os
    ```
 
 2. **Copy agent-os config:**
-   - Read: `/Users/iamanmp/Projects/claude-os/templates/project-files/agent-os/config.yml.template`
+   - Read: `{claude_os_dir}/templates/project-files/agent-os/config.yml.template`
    - Replace `{{TIMESTAMP}}` with current timestamp
    - Write to: `./agent-os/config.yml`
 
 3. **Copy agent-os README:**
-   - Read: `/Users/iamanmp/Projects/claude-os/templates/project-files/agent-os/README.md`
+   - Read: `{claude_os_dir}/templates/project-files/agent-os/README.md`
    - Replace `{{PROJECT_NAME}}` → project_name
    - Write to: `./agent-os/README.md`
 
 4. **Copy agent-os .gitignore:**
-   - Copy: `/Users/iamanmp/Projects/claude-os/templates/project-files/agent-os/.gitignore`
+   - Copy: `{claude_os_dir}/templates/project-files/agent-os/.gitignore`
    - Write to: `./agent-os/.gitignore`
 
 5. **Symlink agent-os agents:**
@@ -208,11 +215,11 @@ mkdir -p .claude-os
    mkdir -p .claude/agents/agent-os
 
    # Symlink all agents
-   ln -s /Users/iamanmp/Projects/claude-os/templates/agents/*.md .claude/agents/agent-os/
+   ln -s {claude_os_dir}/templates/agents/*.md .claude/agents/agent-os/
    ```
 
 6. **Update CLAUDE.md with agent-os section:**
-   - Read: `/Users/iamanmp/Projects/claude-os/templates/project-files/agent-os-section.md`
+   - Read: `{claude_os_dir}/templates/project-files/agent-os-section.md`
    - Replace `{{AGENT_OS_SECTION}}` in CLAUDE.md with this content
    - Or if `{{AGENT_OS_SECTION}}` not present, leave empty
 
@@ -482,10 +489,10 @@ If any step fails:
 ## Template Locations
 
 All templates are in:
-- `/Users/iamanmp/Projects/claude-os/templates/project-files/`
+- `{claude_os_dir}/templates/project-files/`
 
 Commands and skills will be symlinked from:
-- `/Users/iamanmp/Projects/claude-os/templates/commands/`
-- `/Users/iamanmp/Projects/claude-os/templates/skills/`
+- `{claude_os_dir}/templates/commands/`
+- `{claude_os_dir}/templates/skills/`
 
 (These symlinks are set up during Claude OS installation via `./install.sh`)

--- a/templates/commands/claude-os-session.md
+++ b/templates/commands/claude-os-session.md
@@ -7,6 +7,10 @@ description: Intelligent session management with automatic context loading and p
 
 Power-user session workflows that make me smarter with every session.
 
+## Setup
+
+First, derive `{claude_os_dir}` from this command file's path - it is two directories up from this file's location.
+
 ## Commands
 
 ```
@@ -31,7 +35,7 @@ Power-user session workflows that make me smarter with every session.
 
 **Phase 1: Load State**
 ```
-Read: /Users/iamanmp/Projects/claude-os/claude-os-state.json
+Read: {claude_os_dir}/claude-os-state.json
 ```
 
 **Phase 2: Search Recent Memories**
@@ -292,7 +296,7 @@ Type /claude-os-session end when done
 
 ### State File Location
 ```
-/Users/iamanmp/Projects/claude-os/claude-os-state.json
+{claude_os_dir}/claude-os-state.json
 ```
 
 ### Auto-Actions on Start

--- a/templates/commands/claude-os-triggers.md
+++ b/templates/commands/claude-os-triggers.md
@@ -7,6 +7,10 @@ description: Manage Claude OS trigger phrases and automatic skill invocation
 
 Manage trigger phrases that automatically invoke skills and workflows.
 
+## Setup
+
+First, derive `{claude_os_dir}` from this command file's path - it is two directories up from this file's location.
+
 ## Command Pattern
 
 ```
@@ -20,7 +24,7 @@ Manage trigger phrases that automatically invoke skills and workflows.
 **ALWAYS start by loading the triggers config:**
 
 ```bash
-Read: /Users/iamanmp/Projects/claude-os/claude-os-triggers.json
+Read: {claude_os_dir}/claude-os-triggers.json
 ```
 
 ## Step 2: Parse Command and Execute
@@ -229,14 +233,14 @@ When modifying triggers, use this pattern:
 import json
 
 # Load
-with open('/Users/iamanmp/Projects/claude-os/claude-os-triggers.json') as f:
+with open('{claude_os_dir}/claude-os-triggers.json') as f:
     config = json.load(f)
 
 # Modify
 config['triggers']['remember_this']['phrases'].append('new phrase')
 
 # Save
-with open('/Users/iamanmp/Projects/claude-os/claude-os-triggers.json', 'w') as f:
+with open('{claude_os_dir}/claude-os-triggers.json', 'w') as f:
     json.dump(config, f, indent=2)
 ```
 
@@ -266,7 +270,7 @@ Triggers session end workflow (if implemented)
 
 ## Configuration File
 
-Location: `/Users/iamanmp/Projects/claude-os/claude-os-triggers.json`
+Location: `{claude_os_dir}/claude-os-triggers.json`
 
 Structure:
 ```json
@@ -334,4 +338,4 @@ The remember-this skill will be updated to:
 
 **Remember**: These triggers make me more proactive and responsive to your needs!
 
-*Configuration file created at `/Users/iamanmp/Projects/claude-os/claude-os-triggers.json`*
+*Configuration file created at `{claude_os_dir}/claude-os-triggers.json`*

--- a/templates/project-files/CLAUDE.md.template
+++ b/templates/project-files/CLAUDE.md.template
@@ -19,7 +19,7 @@
 - **My knowledge base** of patterns and decisions
 - **My learning system** that improves over time
 
-**Location**: `/Users/iamanmp/Projects/claude-os`
+**Location**: `{{CLAUDE_OS_DIR}}`
 
 The MCP server is called "code-forge" internally for backwards compatibility, but it's Claude OS.
 
@@ -219,9 +219,9 @@ What would you like to do?
 
 ### Related Documentation
 
-- Full protocol: `/Users/iamanmp/Projects/claude-os/docs/guides/SESSION_START_PROTOCOL.md`
-- Ideal workflow: `/Users/iamanmp/Projects/claude-os/docs/guides/IDEAL_SESSION_WORKFLOW.md`
-- Session commands: `/Users/iamanmp/Projects/claude-os/templates/commands/claude-os-session.md`
+- Full protocol: `{{CLAUDE_OS_DIR}}/docs/guides/SESSION_START_PROTOCOL.md`
+- Ideal workflow: `{{CLAUDE_OS_DIR}}/docs/guides/IDEAL_SESSION_WORKFLOW.md`
+- Session commands: `{{CLAUDE_OS_DIR}}/templates/commands/claude-os-session.md`
 
 **Why this matters:** Zero context loss. Every session picks up exactly where we left off. No re-explaining, no starting cold, no wasted time.
 

--- a/templates/skills/initialize-project/SMART_INDEXING_GUIDE.md
+++ b/templates/skills/initialize-project/SMART_INDEXING_GUIDE.md
@@ -105,8 +105,8 @@ Expands the project index with previously unindexed files.
 ```bash
 python3 incremental_indexer.py <project_id> <project_path> [api_url] [batch_size]
 
-# Example: Index next 50 files in PISTN
-python3 incremental_indexer.py 4 /Users/iamanmp/Projects/pistn http://localhost:8051 50
+# Example: Index next 50 files in your project
+python3 incremental_indexer.py <project_id> ~/Projects/my-project http://localhost:8051 50
 ```
 
 Returns JSON with progress:
@@ -125,7 +125,7 @@ If you want to expand the index before the scheduled 10-commit mark:
 
 ```bash
 # Manually trigger expansion
-python3 /Users/iamanmp/.claude/skills/analyze-project/incremental_indexer.py 4 /Users/iamanmp/Projects/pistn
+python3 ~/.claude/skills/analyze-project/incremental_indexer.py <project_id> ~/Projects/my-project
 ```
 
 ## Monitoring Progress

--- a/templates/skills/initialize-project/analyze_project.py
+++ b/templates/skills/initialize-project/analyze_project.py
@@ -221,7 +221,10 @@ class ProjectAnalyzer:
             try:
                 db_path = Path.home() / ".claude" / "projects" / "claude-os" / "data" / "claude-os.db"
                 if not db_path.exists():
-                    db_path = Path("/Users/iamanmp/Projects/claude-os/data/claude-os.db")
+                    # Derive from this script's location (4 levels up from templates/skills/initialize-project/)
+                    script_claude_os = Path(__file__).resolve().parent.parent.parent.parent / "data" / "claude-os.db"
+                    if script_claude_os.exists():
+                        db_path = script_claude_os
 
                 if db_path.exists():
                     conn = sqlite3.connect(str(db_path))
@@ -1212,24 +1215,12 @@ REGISTERED MCPs (load on-demand):
                 print_success("RQ workers already running")
                 return True
 
-            # Find Claude OS project directory
-            # Try multiple locations
-            claude_os_paths = [
-                Path("/Users/iamanmp/Projects/claude-os"),
-                Path.home() / "Projects" / "claude-os",
-                Path("/opt/claude-os"),
-                Path("/srv/claude-os")
-            ]
+            # Find Claude OS project directory from this script's location
+            claude_os_path = Path(__file__).resolve().parent.parent.parent.parent
 
-            claude_os_path = None
-            for path in claude_os_paths:
-                if (path / "start_redis_workers.sh").exists():
-                    claude_os_path = path
-                    break
-
-            if not claude_os_path:
+            if not (claude_os_path / "start_redis_workers.sh").exists():
                 print_warning("Claude OS project not found - cannot start RQ workers")
-                print_info("Expected locations: /Users/iamanmp/Projects/claude-os or ~/Projects/claude-os")
+                print_info("Could not locate start_redis_workers.sh in the claude-os directory")
                 return False
 
             # Start RQ workers in background


### PR DESCRIPTION
## Summary
- Replaces all hardcoded `/Users/iamanmp/` paths with dynamic path discovery
- Makes claude-os work for any user on any system

## Changes
| File | Fix Applied |
|------|-------------|
| `templates/commands/claude-os-init.md` | Added Step 0 to derive `{claude_os_dir}` from this file's path |
| `cli/claude-os-consolidate.sh` | Uses `BASH_SOURCE` to find script location dynamically |
| `templates/skills/initialize-project/analyze_project.py` | Uses `Path(__file__).resolve()` to derive paths |
| `frontend/src/components/ProjectManagement.tsx` | Removed hardcoded default, uses empty string |
| `templates/commands/claude-os-session.md` | Added Setup section, uses `{claude_os_dir}` |
| `templates/commands/claude-os-triggers.md` | Added Setup section, uses `{claude_os_dir}` |
| `templates/project-files/CLAUDE.md.template` | Uses `{{CLAUDE_OS_DIR}}` template variable |
| `templates/skills/initialize-project/SMART_INDEXING_GUIDE.md` | Updated examples to use generic paths |
| `templates/README.md` | Changed to relative path reference |

## Test plan
- [ ] Run `/claude-os-init` on a fresh project
- [ ] Verify all template paths resolve correctly
- [ ] Test on a machine without the `/Users/iamanmp/` directory

Fixes #9