### PR TITLE
Fix: Ensure commands and skills directories exist during install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -114,6 +114,10 @@ else
     echo "✅ ${USER_CLAUDE_DIR} already exists"
 fi
 
+# Ensure commands and skills subdirectories exist (even if .claude already existed)
+mkdir -p "${USER_CLAUDE_DIR}/commands"
+mkdir -p "${USER_CLAUDE_DIR}/skills"
+
 # Create symlinks for commands
 echo ""
 echo "🔗 Setting up command symlinks..."


### PR DESCRIPTION
## Problem

When users have an existing `~/.claude/` directory from a prior Claude Code installation, the `install.sh` script skips creating the `commands/` and `skills/` subdirectories. This causes the symlink creation to fail silently, leaving users without access to `/claude-os-init` and other commands.

## Root Cause

The installation script only creates the subdirectories if `~/.claude/` doesn't exist:

```bash
if [ ! -d "$USER_CLAUDE_DIR" ]; then
    mkdir -p "${USER_CLAUDE_DIR}/commands"
    mkdir -p "${USER_CLAUDE_DIR}/skills"
else
    echo "✅ ${USER_CLAUDE_DIR} already exists"
fi
```

If the directory already exists, it skips creating the subdirectories, leading to:
```
ln: /Users/user/.claude/commands/claude-os-init.md: No such file or directory
```

## Solution

This PR adds two lines after the conditional to ensure the subdirectories are always created:

```bash
# Ensure commands and skills subdirectories exist (even if .claude already existed)
mkdir -p "${USER_CLAUDE_DIR}/commands"
mkdir -p "${USER_CLAUDE_DIR}/skills"
```

## Testing

Tested the fix by:
1. Removing `~/.claude/commands` and `~/.claude/skills`
2. Running the updated `install.sh` script
3. Verifying all 8 commands and 3 skills were symlinked successfully
4. Confirming `/claude-os-init` is now available in Claude Code

## Impact

This is a minimal, safe change that:
- ✅ Fixes the bug for users with existing `~/.claude/` directories
- ✅ Doesn't affect new installations (subdirectories already created)
- ✅ Uses `mkdir -p` which is idempotent and safe to run multiple times
- ✅ No breaking changes

Fixes issue reported by users where `/claude-os-init` command was not available after installation.