### PR TITLE
Fix frontend startup by auto-installing npm dependencies

### DIFF
--- a/start_all_services.sh
+++ b/start_all_services.sh
@@ -194,6 +194,21 @@ if check_port 5173; then
 fi
 
 cd "$PROJECT_DIR/frontend"
+
+# Check if node_modules exists, install dependencies if not
+if [ ! -d "node_modules" ]; then
+    echo "   Installing frontend dependencies..."
+    npm install > "$PROJECT_DIR/logs/frontend.log" 2>&1
+    if [ $? -eq 0 ]; then
+        echo -e "   ${GREEN}✓ Frontend dependencies installed${NC}"
+    else
+        echo -e "   ${RED}❌ Failed to install frontend dependencies${NC}"
+        echo "   Check logs with: tail -f logs/frontend.log"
+        cd "$PROJECT_DIR"
+        exit 1
+    fi
+fi
+
 nohup npm run dev -- --host 0.0.0.0 > "$PROJECT_DIR/logs/frontend.log" 2>&1 &
 FRONTEND_PID=$!
 echo "   Frontend PID: $FRONTEND_PID (logging to logs/frontend.log)"


### PR DESCRIPTION
## Summary

- Fixes "vite: command not found" error for new users running `./start_all_services.sh`
- The script now checks if `node_modules` exists in the frontend directory
- Automatically runs `npm install` if dependencies are missing
- Provides clear error message if npm install fails

## Problem

New users cloning the repo and running `./start_all_services.sh` would get:

```
sh: vite: command not found
```

Because the script assumed npm dependencies were already installed.

## Test plan

- [ ] Clone fresh repo (or delete `frontend/node_modules`)
- [ ] Run `./start_all_services.sh`
- [ ] Verify frontend dependencies are installed automatically
- [ ] Verify frontend starts successfully on port 5173