### PR TITLE
Fix tree-sitter version compatibility with tree-sitter-languages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,9 @@ sqlite-vec>=0.1.0
 numpy>=1.24.0
 
 # Tree-sitter for fast structural indexing
-tree-sitter>=0.21.0
+# NOTE: tree-sitter-languages 1.10.x is incompatible with tree-sitter 0.21+
+# The 0.21+ API changed Parser() and Language() constructors breaking the library
+tree-sitter>=0.20.0,<0.21.0
 tree-sitter-languages>=1.10.0  # Pre-built binaries for 40+ languages
 networkx>=3.2.1  # For dependency graphs and PageRank
 


### PR DESCRIPTION
## Summary
- Pin tree-sitter to 0.20.x for compatibility with tree-sitter-languages 1.10.x
- The tree-sitter 0.21+ API changed `Parser()` and `Language()` constructors, breaking tree-sitter-languages
- This was causing `__init__() takes exactly 1 argument (2 given)` errors on all file parsing

## Problem
Selective indexing was completely broken because TreeSitter failed to parse any files:
```
Failed to parse /path/to/file.tsx: __init__() takes exactly 1 argument (2 given)
```

This resulted in 0 symbols being extracted, making the "top 20% important files" selection return 0 files.

## Solution
Pin tree-sitter to `>=0.20.0,<0.21.0` until tree-sitter-languages is updated to support the new API.

## Test plan
- [x] Verified tree-sitter 0.20.4 works with tree-sitter-languages 1.10.2
- [x] Tested selective indexing completes successfully (87 files indexed)
- [x] Verified TreeSitter parses files without errors