### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Claude OS
 
+[![Run in Smithery](https://smithery.ai/badge/skills/brobertsaz)](https://smithery.ai/skills?ns=brobertsaz&utm_source=github&utm_medium=badge)
+
+
 <p align="center">
   <img src="frontend/public/assets/claude-os-hero.png" alt="Claude OS Hero" width="800"/>
 </p>


### PR DESCRIPTION
## Add skill discoverability badge

Your 1 Claude skill is already indexed on [Smithery](https://smithery.ai), a directory of Claude Skills and MCP servers. This badge links users directly to your skills.

### Badge Preview
[![Run in Smithery](https://smithery.ai/badge/skills/brobertsaz)](https://smithery.ai/skills?ns=brobertsaz&utm_source=github&utm_medium=badge)

### Why add this?
- Users browsing your repo can discover and install your skills with one click
- No additional setup required - your skills are already listed

---

This is optional. Feel free to close if you prefer not to add external badges.