### PR TITLE
Fix vendored dirs in semantic indexing, pin mcp<2, fix index_structural 422

### DIFF
--- a/mcp_server/claude_code_mcp.py
+++ b/mcp_server/claude_code_mcp.py
@@ -606,7 +606,8 @@ async def _execute_tool(name: str, args: dict[str, Any]) -> dict:
     # Indexing Tools
     elif name == "index_structural":
         return await api_post(f"/api/kb/{args['kb_name']}/index-structural", {
-            "path": args["path"]
+            # API expects "project_path" - sending "path" returns 422
+            "project_path": args["path"]
         })
 
     elif name == "index_semantic":

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -988,6 +988,27 @@ async def api_index_structural(kb_name: str, request: StructuralIndexRequest):
         raise HTTPException(status_code=500, detail=str(e))
 
 
+def _collect_doc_files(project_path: str) -> list:
+    """
+    Collect documentation files (*.md, *.txt, *.rst) under project_path.
+
+    Applies TreeSitterIndexer.SKIP_DIRS so vendored trees (venv, node_modules,
+    .git, ...) are excluded. Without this filter a bare rglob pulls in every
+    README/LICENSE/top_level.txt shipped by third-party packages, which both
+    floods the KB with irrelevant chunks and makes indexing take many times
+    longer than it should.
+    """
+    from app.core.tree_sitter_indexer import TreeSitterIndexer
+
+    skip = TreeSitterIndexer.SKIP_DIRS
+    doc_files = []
+    for pattern in ("*.md", "*.txt", "*.rst"):
+        for f in Path(project_path).rglob(pattern):
+            if not any(part in skip for part in f.parts):
+                doc_files.append(f)
+    return doc_files
+
+
 def _run_semantic_indexing_background(job_id: str, kb_name: str, project_path: str, selective: bool, personalization: dict = None):
     """
     Background worker for semantic indexing. Runs in a separate thread to avoid blocking.
@@ -1027,11 +1048,8 @@ def _run_semantic_indexing_background(job_id: str, kb_name: str, project_path: s
             important_tags = repo_map.tags[:top_20_percent]
             important_files = list(set(tag.file for tag in important_tags))
 
-            # Add all documentation files
-            docs_patterns = ["*.md", "*.txt", "*.rst"]
-            doc_files = []
-            for pattern in docs_patterns:
-                doc_files.extend(Path(project_path).rglob(pattern))
+            # Add all documentation files (vendored dirs excluded)
+            doc_files = _collect_doc_files(project_path)
 
             all_files = list(set(important_files + [str(f.relative_to(project_path)) for f in doc_files]))
             total_files = len(all_files)
@@ -1099,10 +1117,7 @@ def _run_semantic_indexing_sync(kb_name: str, project_path: str, selective: bool
         important_tags = repo_map.tags[:top_20_percent]
         important_files = list(set(tag.file for tag in important_tags))
 
-        docs_patterns = ["*.md", "*.txt", "*.rst"]
-        doc_files = []
-        for pattern in docs_patterns:
-            doc_files.extend(Path(project_path).rglob(pattern))
+        doc_files = _collect_doc_files(project_path)
 
         all_files = list(set(important_files + [str(f.relative_to(project_path)) for f in doc_files]))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,9 @@ sentence-transformers>=2.2.0
 rank-bm25>=0.2.2
 
 # MCP Server
-mcp>=1.0.0
+# NOTE: mcp 2.0+ removed the decorator API (@server.list_tools()) used by
+# mcp_server/claude_code_mcp.py -> AttributeError at import. Pinned to 1.x.
+mcp>=1.0.0,<2.0.0
 fastapi>=0.104.0
 uvicorn>=0.24.0
 pydantic>=2.0.0

--- a/start-claude-os.ps1
+++ b/start-claude-os.ps1
@@ -1,0 +1,90 @@
+# ============================================================================
+# Claude OS - Démarrage des services (équivalent Windows de start_all_services.sh)
+# Usage :  .\start-claude-os.ps1
+# ============================================================================
+
+$ErrorActionPreference = "Stop"
+$ProjectDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+Write-Host ""
+Write-Host "=== Claude OS - Demarrage ===" -ForegroundColor Cyan
+Write-Host ""
+
+# --- Dossiers requis ---
+foreach ($d in @("data", "logs")) {
+    if (-not (Test-Path "$ProjectDir\$d")) {
+        New-Item -ItemType Directory "$ProjectDir\$d" -Force | Out-Null
+    }
+}
+
+# --- 1. Ollama ---
+Write-Host "[1/3] Ollama..." -NoNewline
+try {
+    Invoke-WebRequest -Uri "http://localhost:11434" -UseBasicParsing -TimeoutSec 5 | Out-Null
+    Write-Host " deja en cours" -ForegroundColor Green
+} catch {
+    Write-Host " demarrage..." -NoNewline
+    Start-Process "ollama" -ArgumentList "serve" -WindowStyle Hidden
+    Start-Sleep -Seconds 5
+    Write-Host " ok" -ForegroundColor Green
+}
+
+# --- 2. API Server (port 8051) ---
+Write-Host "[2/3] API Server..." -NoNewline
+$apiUp = $false
+try {
+    Invoke-WebRequest -Uri "http://localhost:8051/docs" -UseBasicParsing -TimeoutSec 5 | Out-Null
+    $apiUp = $true
+} catch { }
+
+if ($apiUp) {
+    Write-Host " deja en cours" -ForegroundColor Green
+} else {
+    $env:SQLITE_DB_PATH = "$ProjectDir\data\claude-os.db"
+    Start-Process -FilePath "$ProjectDir\venv\Scripts\python.exe" `
+                  -ArgumentList "server.py" `
+                  -WorkingDirectory "$ProjectDir\mcp_server" `
+                  -RedirectStandardOutput "$ProjectDir\logs\mcp_server.log" `
+                  -RedirectStandardError "$ProjectDir\logs\mcp_server.err.log" `
+                  -WindowStyle Hidden
+    # Attente jusqu'a 30s
+    $ok = $false
+    for ($i = 0; $i -lt 15; $i++) {
+        Start-Sleep -Seconds 2
+        try {
+            Invoke-WebRequest -Uri "http://localhost:8051/docs" -UseBasicParsing -TimeoutSec 3 | Out-Null
+            $ok = $true; break
+        } catch { }
+    }
+    if ($ok) { Write-Host " ok" -ForegroundColor Green }
+    else { Write-Host " ECHEC - voir logs\mcp_server.err.log" -ForegroundColor Red }
+}
+
+# --- 3. Frontend (port 5173) ---
+Write-Host "[3/3] Frontend..." -NoNewline
+$feUp = $false
+try {
+    Invoke-WebRequest -Uri "http://localhost:5173" -UseBasicParsing -TimeoutSec 5 | Out-Null
+    $feUp = $true
+} catch { }
+
+if ($feUp) {
+    Write-Host " deja en cours" -ForegroundColor Green
+} else {
+    if (-not (Test-Path "$ProjectDir\frontend\node_modules")) {
+        Write-Host " installation npm..." -NoNewline
+        Push-Location "$ProjectDir\frontend"; npm install | Out-Null; Pop-Location
+    }
+    Start-Process "npm" -ArgumentList "run", "dev" `
+                  -WorkingDirectory "$ProjectDir\frontend" `
+                  -WindowStyle Hidden
+    Start-Sleep -Seconds 8
+    Write-Host " ok" -ForegroundColor Green
+}
+
+Write-Host ""
+Write-Host "Interface  : http://localhost:5173" -ForegroundColor Yellow
+Write-Host "API / docs : http://localhost:8051/docs" -ForegroundColor Yellow
+Write-Host ""
+Write-Host "Pour arreter : .\stop-claude-os.ps1" -ForegroundColor DarkGray
+Write-Host ""

--- a/stop-claude-os.ps1
+++ b/stop-claude-os.ps1
@@ -1,0 +1,30 @@
+# ============================================================================
+# Claude OS - Arrêt des services (équivalent Windows de stop_all_services.sh)
+# Usage :  .\stop-claude-os.ps1
+# ============================================================================
+
+Write-Host ""
+Write-Host "=== Claude OS - Arret ===" -ForegroundColor Cyan
+
+# Arrete les processus ecoutant sur les ports 8051 (API) et 5173 (frontend)
+foreach ($port in @(8051, 5173)) {
+    $conns = Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue
+    if ($conns) {
+        foreach ($pid_ in ($conns.OwningProcess | Select-Object -Unique)) {
+            try {
+                $name = (Get-Process -Id $pid_ -ErrorAction Stop).ProcessName
+                Stop-Process -Id $pid_ -Force -ErrorAction Stop
+                Write-Host "  Port ${port} : $name (PID $pid_) arrete" -ForegroundColor Green
+            } catch {
+                Write-Host "  Port ${port} : impossible d'arreter le PID $pid_" -ForegroundColor Yellow
+            }
+        }
+    } else {
+        Write-Host "  Port ${port} : rien en ecoute" -ForegroundColor DarkGray
+    }
+}
+
+Write-Host ""
+Write-Host "Note : Ollama reste actif (service Windows). Pour l'arreter :" -ForegroundColor DarkGray
+Write-Host "  Get-Process ollama* | Stop-Process -Force" -ForegroundColor DarkGray
+Write-Host ""


### PR DESCRIPTION
## Summary

Three defects hit while installing Claude OS on a clean machine (native Windows, Ollama), plus PowerShell equivalents of the bash start/stop scripts.

Each fix is independent and small. Happy to split into separate PRs if you prefer.

---

## 1. Semantic indexing ingests `venv/` and `node_modules/`

**Impact:** high — this silently poisons the knowledge base and makes indexing an order of magnitude slower.

In selective mode, code files are filtered correctly because they come from `TreeSitterIndexer`, which applies its `SKIP_DIRS`. The documentation pass does not:

```python
docs_patterns = ["*.md", "*.txt", "*.rst"]
for pattern in docs_patterns:
    doc_files.extend(Path(project_path).rglob(pattern))
```

A bare `rglob` sweeps up every `README.md`, `LICENSE.txt`, `top_level.txt` and `entry_points.txt` shipped by third-party packages.

Measured on this repository (225 real source files):

| | Before | After |
|---|---|---|
| Files selected | 935 | **66** |
| Duration | ~40 min | **3m22** |
| Docs from `venv`/`node_modules` in the KB | 283 / 306 | **0 / 67** |

Fix: added `_collect_doc_files()`, which reuses `TreeSitterIndexer.SKIP_DIRS`, and called it from both `_run_semantic_indexing_background` and `_run_semantic_indexing_sync` (both had the bug).

Note for anyone applying this by hand: `TreeSitterIndexer` is imported *inside* those functions, not at module level, so the helper needs its own import.

## 2. `mcp>=1.0.0` is too permissive

pip now resolves it to `mcp` 2.0.0, which removed the decorator API used by `claude_code_mcp.py`. The MCP server dies at import:

```
File "mcp_server/claude_code_mcp.py", line 142, in <module>
    @server.list_tools()
AttributeError: 'Server' object has no attribute 'list_tools'
```

A fresh `pip install -r requirements.txt` therefore produces a non-functional MCP server. Pinned to `<2.0.0` as a stopgap — migrating to the 2.x API would be the real fix, but that is a larger change.

## 3. `index_structural` MCP tool always returns HTTP 422

`claude_code_mcp.py` posts `{"path": ...}` while `StructuralIndexRequest` expects `project_path`, so the tool never worked from Claude Code.

## 4. PowerShell start/stop scripts (new files)

`start_all_services.sh` / `stop_all_services.sh` cannot run on native Windows without WSL, and hardcode `venv/bin/python3` (it is `venv\Scripts\python.exe` there).

`start-claude-os.ps1` and `stop-claude-os.ps1` are direct equivalents: create `data/` and `logs/`, start Ollama / API / frontend only if the port is not already listening, wait for each to answer, print the URLs. Stop works off listening ports rather than PID files.

Redis is deliberately not started — it is only used by the background learning jobs and the status dashboard, has no native Windows build, and memory / RAG search / MCP all work without it.

---

## Testing

- `index-structural` on this repo: 90 files, 1345 symbols, 10s
- `index-semantic` after the fix: 66/66 files, 633 chunks, 3m22, zero vendored paths in `GET /api/kb/{kb}/documents`
- MCP server loads and `health_check` responds with `mcp` pinned to 1.29.0
- Both PowerShell scripts exercised on Windows 11 with Python 3.12.10 and Ollama 0.32.5

## Not addressed

- `data/health_cache.json` is written at runtime but is not in `.gitignore`, so `data/` always shows up as untracked (`*.db` is ignored, the JSON is not). Trivial, left out to keep this focused.